### PR TITLE
Making wicket-bootstrap OSGi compatible

### DIFF
--- a/itests/pom.xml
+++ b/itests/pom.xml
@@ -1,0 +1,92 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<parent>
+		<groupId>de.agilecoders.wicket.webjars</groupId>
+		<artifactId>wicket-webjars-parent</artifactId>
+		<version>0.2.1-SNAPSHOT</version>
+	</parent>
+
+	<groupId>de.agilecoders.wicket.webjars</groupId>
+	<artifactId>wicket-webjars-itests</artifactId>
+	<version>0.2.1-SNAPSHOT</version>
+	<packaging>jar</packaging>
+	<name>itests</name>
+
+	<dependencies>
+
+		<dependency>
+			<groupId>junit</groupId>
+			<artifactId>junit</artifactId>
+			<version>${junit.version}</version>
+		</dependency>
+
+		<!-- Pax Exam - OSGi Testing Framework -->
+		<dependency>
+			<groupId>org.ops4j.pax.exam</groupId>
+			<artifactId>pax-exam-junit4</artifactId>
+			<version>${exam.version}</version>
+			<scope>test</scope>
+		</dependency>
+
+		<!-- Apache Karaf Pax Exam Bridge -->
+		<dependency>
+			<groupId>org.apache.karaf.tooling.exam</groupId>
+			<artifactId>org.apache.karaf.tooling.exam.container</artifactId>
+			<version>${karaf.tooling.version}</version>
+			<scope>test</scope>
+		</dependency>
+
+		<!-- Apache Karaf -->
+		<dependency>
+			<groupId>org.apache.karaf</groupId>
+			<artifactId>apache-karaf</artifactId>
+			<version>${karaf.version}</version>
+			<type>zip</type>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>de.agilecoders.wicket.webjars</groupId>
+			<artifactId>wicket-webjars</artifactId>
+		</dependency>
+	</dependencies>
+
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-compiler-plugin</artifactId>
+				<version>2.5.1</version>
+				<configuration>
+					<source>${mvn.build.java.version}</source>
+					<target>${mvn.build.java.version}</target>
+					<compilerVersion>${mvn.build.java.version}</compilerVersion>
+					<encoding>${project.build.sourceEncoding}</encoding>
+					<showDeprecation>true</showDeprecation>
+					<showWarnings>true</showWarnings>
+					<optimize>true</optimize>
+				</configuration>
+			</plugin>
+
+			<!-- Generate depends file, so versionAsInProject() works -->
+			<plugin>
+				<groupId>org.apache.servicemix.tooling</groupId>
+				<artifactId>depends-maven-plugin</artifactId>
+				<version>${plugin.depends.version}</version>
+				<executions>
+					<execution>
+						<id>generate-depends-file</id>
+						<goals>
+							<goal>generate-depends-file</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+	</build>
+
+	<description>A simple integration test, to prove that webjars are now able to function in an OSGi container.</description>
+</project>

--- a/itests/src/main/features/features.xml
+++ b/itests/src/main/features/features.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<features xmlns="http://karaf.apache.org/xmlns/features/v1.0.0">
+
+	<!-- This features XML allows us to provision Karaf easily and consistently. 
+	Each feature installs a set of bundles, which once ready provide an environment within which we can run unit tests -->
+	<feature name="wicket" version="6.6.0">
+		<bundle dependency="true">wrap:mvn:org.apache.wicket/wicket-core/6.6.0</bundle>
+		<bundle dependency="true">wrap:mvn:org.apache.wicket/wicket-request/6.6.0</bundle>
+		<bundle dependency="true">wrap:mvn:org.apache.wicket/wicket-util/6.6.0</bundle>
+	</feature>
+
+	<feature name="supportingLibs" version="0.8.2-SNAPSHOT">
+		<bundle dependency="true">wrap:mvn:org.reflections/reflections/0.9.8</bundle>
+		<bundle dependency="true">mvn:com.google.guava/guava/13.0.1</bundle>
+		<bundle dependency="true">wrap:mvn:org.apache.directory.studio/org.apache.commons.lang/2.6</bundle>
+	</feature>
+
+	<feature name="webjars" version="0.2.1-SNAPSHOT">
+		<bundle dependency="true">mvn:de.agilecoders.wicket.webjars/wicket-webjars/0.2.1-SNAPSHOT</bundle>
+		<bundle dependency="true">mvn:de.agilecoders.wicket.webjars/webjar-container-fragment/0.2.1-SNAPSHOT</bundle>
+		<bundle dependency="true">wrap:mvn:org.webjars/webjars-locator/0.1</bundle>
+	</feature>
+</features>

--- a/itests/src/test/java/de/agilecoders/wicket/webjars/itests/OSGIContainerTest.java
+++ b/itests/src/test/java/de/agilecoders/wicket/webjars/itests/OSGIContainerTest.java
@@ -1,0 +1,92 @@
+package de.agilecoders.wicket.webjars.itests;
+
+import static org.apache.karaf.tooling.exam.options.KarafDistributionOption.debugConfiguration;
+import static org.apache.karaf.tooling.exam.options.KarafDistributionOption.editConfigurationFileExtend;
+import static org.apache.karaf.tooling.exam.options.KarafDistributionOption.karafDistributionConfiguration;
+import static org.hamcrest.core.IsNull.notNullValue;
+import static org.junit.Assert.assertThat;
+import static org.ops4j.pax.exam.CoreOptions.junitBundles;
+import static org.ops4j.pax.exam.CoreOptions.maven;
+import static org.ops4j.pax.exam.CoreOptions.options;
+
+import java.io.File;
+import java.io.IOException;
+
+import org.apache.karaf.tooling.exam.options.configs.FeaturesCfg;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.ops4j.pax.exam.ExamSystem;
+import org.ops4j.pax.exam.Option;
+import org.ops4j.pax.exam.TestContainer;
+import org.ops4j.pax.exam.junit.Configuration;
+import org.ops4j.pax.exam.junit.ExamReactorStrategy;
+import org.ops4j.pax.exam.junit.JUnit4TestRunner;
+import org.ops4j.pax.exam.spi.PaxExamRuntime;
+import org.ops4j.pax.exam.spi.reactors.AllConfinedStagedReactorFactory;
+import org.reflections.vfs.Vfs;
+
+import de.agilecoders.wicket.webjars.request.resource.WebjarsJavaScriptResourceReference;
+import de.agilecoders.wicket.webjars.util.file.WebjarsResourceFinder;
+import de.agilecoders.wicket.webjars.util.osgi.BundleUrlType;
+
+/**
+ * This test class lets us spin up an OSGi container, deploy the required
+ * dependencies and then run unit test wihthin the container to check.
+ * 
+ * @author ben
+ * 
+ */
+@RunWith(JUnit4TestRunner.class)
+@ExamReactorStrategy(AllConfinedStagedReactorFactory.class)
+public class OSGIContainerTest {
+
+	@Configuration
+	public Option[] config() {
+
+		String featuresXmlPath = null;
+
+		try {
+			featuresXmlPath = new File("src/main/features/features.xml").getCanonicalPath();
+		} catch (IOException e) {
+			e.printStackTrace();
+		}
+
+		return options(
+
+				// Needed to enable the junit OSGi probe
+				junitBundles(),
+
+				// Set up Apache Karaf as the OSGi container. Note this gets the
+				// ZIP from Maven, so including it in the pom ensures it in the
+				// local repo speeding up the tests
+				karafDistributionConfiguration().frameworkUrl(maven("org.apache.karaf", "apache-karaf").type("zip").versionAsInProject()).karafVersion("3.2.1").name("Apache Karaf"),
+
+				//Install the feaures in our features.xml file
+				editConfigurationFileExtend(FeaturesCfg.BOOT, ",supportingLibs,wicket,webjars"),
+				
+				//The features are described by XML files found in these locations, one via Maven, one local
+				editConfigurationFileExtend(FeaturesCfg.REPOSITORIES, 
+						",mvn:org.ops4j.pax.wicket/features/2.1.0/xml/features" + 
+						",file:" + featuresXmlPath), debugConfiguration("5005", false));
+	}
+
+	@Test
+	public void testResourceCanBeFound() {
+		
+		//Register the URL handler
+		Vfs.addDefaultURLTypes(new BundleUrlType());
+		
+		//Now try to grab the resource
+		WebjarsResourceFinder finder = WebjarsResourceFinder.instance();
+		assertThat(finder.find(WebjarsJavaScriptResourceReference.class, "/webjars/jquerypp/1.0b2/amd/jquerypp/range.js"), notNullValue());
+	}
+
+	
+	//This allows us to spin up the container and access it through the CLI.
+	public static void main(String[] args) throws Exception {
+		OSGIContainerTest sampleTest = new OSGIContainerTest();
+		ExamSystem system = PaxExamRuntime.createServerSystem(sampleTest.config());
+		TestContainer container = PaxExamRuntime.createContainer(system);
+		container.start();
+	}
+}

--- a/library/pom.xml
+++ b/library/pom.xml
@@ -1,24 +1,35 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-    <modelVersion>4.0.0</modelVersion>
+	<modelVersion>4.0.0</modelVersion>
 
-    <parent>
-        <groupId>de.agilecoders.wicket.webjars</groupId>
-        <artifactId>wicket-webjars-parent</artifactId>
-        <version>0.2.1-SNAPSHOT</version>
-    </parent>
+	<parent>
+		<groupId>de.agilecoders.wicket.webjars</groupId>
+		<artifactId>wicket-webjars-parent</artifactId>
+		<version>0.2.1-SNAPSHOT</version>
+	</parent>
 
-    <groupId>de.agilecoders.wicket.webjars</groupId>
-    <artifactId>wicket-webjars</artifactId>
-    <version>0.2.1-SNAPSHOT</version>
-    <packaging>jar</packaging>
-    <name>library</name>
+	<groupId>de.agilecoders.wicket.webjars</groupId>
+	<artifactId>wicket-webjars</artifactId>
+	<version>0.2.1-SNAPSHOT</version>
+	<packaging>bundle</packaging>
+	<name>library</name>
 
 	<dependencies>
 		<dependency>
 			<groupId>org.osgi</groupId>
 			<artifactId>org.osgi.core</artifactId>
-			<version>4.2.0</version>
+			<version>${osgi.core.version}</version>
+		</dependency>
+
+		<dependency>
+			<groupId>junit</groupId>
+			<artifactId>junit</artifactId>
+			<version>${junit.version}</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.webjars</groupId>
+			<artifactId>webjars-locator</artifactId>
 		</dependency>
 	</dependencies>
 
@@ -54,7 +65,6 @@
 					</instructions>
 				</configuration>
 			</plugin>
-
 		</plugins>
 	</build>
 </project>

--- a/library/pom.xml
+++ b/library/pom.xml
@@ -14,22 +14,47 @@
     <packaging>jar</packaging>
     <name>library</name>
 
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <version>2.5.1</version>
-                <configuration>
-                    <source>${mvn.build.java.version}</source>
-                    <target>${mvn.build.java.version}</target>
-                    <compilerVersion>${mvn.build.java.version}</compilerVersion>
-                    <encoding>${project.build.sourceEncoding}</encoding>
-                    <showDeprecation>true</showDeprecation>
-                    <showWarnings>true</showWarnings>
-                    <optimize>true</optimize>
-                </configuration>
-            </plugin>
-        </plugins>
-    </build>
+	<dependencies>
+		<dependency>
+			<groupId>org.osgi</groupId>
+			<artifactId>org.osgi.core</artifactId>
+			<version>4.2.0</version>
+		</dependency>
+	</dependencies>
+
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-compiler-plugin</artifactId>
+				<version>2.5.1</version>
+				<configuration>
+					<source>${mvn.build.java.version}</source>
+					<target>${mvn.build.java.version}</target>
+					<compilerVersion>${mvn.build.java.version}</compilerVersion>
+					<encoding>${project.build.sourceEncoding}</encoding>
+					<showDeprecation>true</showDeprecation>
+					<showWarnings>true</showWarnings>
+					<optimize>true</optimize>
+				</configuration>
+			</plugin>
+
+
+			<!-- BD - Allows for jar to be built with an OSGi compatiable manifest -->
+			<plugin>
+				<groupId>org.apache.felix</groupId>
+				<artifactId>maven-bundle-plugin</artifactId>
+				<version>2.3.7</version>
+				<extensions>true</extensions>
+				<configuration>
+					<instructions>
+						<Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
+						<Bundle-Version>${project.version}</Bundle-Version>
+					</instructions>
+				</configuration>
+			</plugin>
+
+		</plugins>
+	</build>
 </project>

--- a/library/src/main/java/de/agilecoders/wicket/webjars/util/RecentVersionCallable.java
+++ b/library/src/main/java/de/agilecoders/wicket/webjars/util/RecentVersionCallable.java
@@ -1,21 +1,25 @@
 package de.agilecoders.wicket.webjars.util;
 
-import com.google.common.collect.Lists;
-import com.google.common.collect.Multimap;
-import org.apache.commons.lang.StringUtils;
-import org.reflections.Reflections;
-import org.reflections.scanners.ResourcesScanner;
-import org.reflections.util.ClasspathHelper;
-import org.reflections.util.ConfigurationBuilder;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.webjars.AssetLocator;
-
 import java.util.List;
 import java.util.concurrent.Callable;
 import java.util.concurrent.FutureTask;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+
+import org.apache.commons.lang.StringUtils;
+import org.reflections.Reflections;
+import org.reflections.scanners.ResourcesScanner;
+import org.reflections.util.ClasspathHelper;
+import org.reflections.util.ConfigurationBuilder;
+import org.reflections.vfs.Vfs;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.webjars.AssetLocator;
+
+import com.google.common.collect.Lists;
+import com.google.common.collect.Multimap;
+
+import de.agilecoders.wicket.webjars.util.osgi.BundleUrlType;
 
 /**
  * Callable that loads the recent version string of given webjars resource
@@ -31,7 +35,12 @@ public class RecentVersionCallable implements Callable<String> {
      * Holder for reflection framework configuration builder
      */
     private static final class AssetLocatorConfigurationBuilder {
-        private static ConfigurationBuilder instance = new ConfigurationBuilder()
+        static {
+        	//BD - This ensures that anything with the bundle protocol can be handled
+        	Vfs.addDefaultURLTypes(new BundleUrlType());
+        }
+    	
+    	private static ConfigurationBuilder instance = new ConfigurationBuilder() 
                 .addUrls(ClasspathHelper.forPackage(StringUtils.join(AssetLocator.WEBJARS_PATH_PREFIX, "."), AssetLocator.class.getClassLoader()))
                 .setScanners(new ResourcesScanner());
     }

--- a/library/src/main/java/de/agilecoders/wicket/webjars/util/file/WebjarsResourceFinder.java
+++ b/library/src/main/java/de/agilecoders/wicket/webjars/util/file/WebjarsResourceFinder.java
@@ -72,7 +72,7 @@ public class WebjarsResourceFinder implements IResourceFinder {
     @Override
     public IResourceStream find(final Class<?> clazz, final String pathName) {
         if (IWebjarsResourceReference.class.isAssignableFrom(clazz)) {
-            final int pos = pathName != null ? pathName.lastIndexOf("/webjars/") : -1;
+            final int pos = pathName != null ? pathName.lastIndexOf("webjars/") : -1;
 
             if (pos > -1) {
                 try {

--- a/library/src/main/java/de/agilecoders/wicket/webjars/util/file/WebjarsResourceFinder.java
+++ b/library/src/main/java/de/agilecoders/wicket/webjars/util/file/WebjarsResourceFinder.java
@@ -1,6 +1,10 @@
 package de.agilecoders.wicket.webjars.util.file;
 
-import de.agilecoders.wicket.webjars.request.resource.IWebjarsResourceReference;
+import java.lang.ref.WeakReference;
+import java.net.URL;
+import java.util.HashSet;
+import java.util.Set;
+
 import org.apache.wicket.WicketRuntimeException;
 import org.apache.wicket.core.util.resource.UrlResourceStream;
 import org.apache.wicket.util.file.IResourceFinder;
@@ -10,10 +14,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.webjars.AssetLocator;
 
-import java.lang.ref.WeakReference;
-import java.net.URL;
-import java.util.HashSet;
-import java.util.Set;
+import de.agilecoders.wicket.webjars.request.resource.IWebjarsResourceReference;
 
 /**
  * Knows how to find webjars resources.

--- a/library/src/main/java/de/agilecoders/wicket/webjars/util/osgi/BundleDir.java
+++ b/library/src/main/java/de/agilecoders/wicket/webjars/util/osgi/BundleDir.java
@@ -1,0 +1,67 @@
+package de.agilecoders.wicket.webjars.util.osgi;
+
+import java.net.URL;
+import java.util.Enumeration;
+import java.util.Iterator;
+
+import org.osgi.framework.Bundle;
+import org.reflections.vfs.Vfs;
+import org.reflections.vfs.Vfs.Dir;
+import org.reflections.vfs.Vfs.File;
+
+import com.google.common.collect.AbstractIterator;
+
+/**
+ * Let's us find all of the file entries both provided by the bundle its self
+ * and any attached fragments
+ * 
+ * @author ben
+ * 
+ */
+public class BundleDir implements Dir {
+
+	private Bundle bundle;
+	private URL url;
+
+	public BundleDir(Bundle bundle, URL url) {
+		this.url = url;
+		this.bundle = bundle;
+	}
+
+	@Override
+	public String getPath() {
+		return url.getPath();
+	}
+
+	@Override
+	public Iterable<File> getFiles() {
+		return new Iterable<Vfs.File>() {
+			public Iterator<Vfs.File> iterator() {
+				return new AbstractIterator<Vfs.File>() {
+
+					//BD - Get all of the entries in this bundle
+					final Enumeration<URL> entries = bundle.findEntries("", "*", true);
+
+					protected Vfs.File computeNext() {
+						while (entries.hasMoreElements()) {
+							URL entry = entries.nextElement();
+
+							//BD - Exclude dirs, as with ZipDir
+							if (!entry.getFile().endsWith("/")) {
+								return new BundleFile(BundleDir.this, entry);
+							}
+						}
+
+						return endOfData();
+					}
+				};
+			}
+		};
+	}
+
+	@Override
+	public void close() {
+
+	}
+
+}

--- a/library/src/main/java/de/agilecoders/wicket/webjars/util/osgi/BundleDir.java
+++ b/library/src/main/java/de/agilecoders/wicket/webjars/util/osgi/BundleDir.java
@@ -39,16 +39,19 @@ public class BundleDir implements Dir {
 			public Iterator<Vfs.File> iterator() {
 				return new AbstractIterator<Vfs.File>() {
 
-					//BD - Get all of the entries in this bundle
+					// BD - Get all of the entries in this bundle
 					final Enumeration<URL> entries = bundle.findEntries("", "*", true);
 
 					protected Vfs.File computeNext() {
-						while (entries.hasMoreElements()) {
-							URL entry = entries.nextElement();
 
-							//BD - Exclude dirs, as with ZipDir
-							if (!entry.getFile().endsWith("/")) {
-								return new BundleFile(BundleDir.this, entry);
+						if (entries != null) {
+							while (entries.hasMoreElements()) {
+								URL entry = entries.nextElement();
+
+								// BD - Exclude dirs, as with ZipDir
+								if (!entry.getFile().endsWith("/")) {
+									return new BundleFile(BundleDir.this, entry);
+								}
 							}
 						}
 

--- a/library/src/main/java/de/agilecoders/wicket/webjars/util/osgi/BundleFile.java
+++ b/library/src/main/java/de/agilecoders/wicket/webjars/util/osgi/BundleFile.java
@@ -1,0 +1,41 @@
+package de.agilecoders.wicket.webjars.util.osgi;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+
+import org.reflections.vfs.Vfs.File;
+
+/**
+ * Turns the individual file {@link URL} objects into files that can be accesed
+ * on disk
+ * 
+ * @author ben
+ * 
+ */
+public class BundleFile implements File {
+
+	private BundleDir bundleDir;
+	private URL url;
+
+	public BundleFile(BundleDir bundleDir, URL url) {
+		this.bundleDir = bundleDir;
+		this.url = url;
+	}
+
+	@Override
+	public String getName() {
+		return getRelativePath().substring(getRelativePath().lastIndexOf("/") + 1);
+	}
+
+	@Override
+	public String getRelativePath() {
+		return url.getFile().substring(bundleDir.getPath().length());
+	}
+
+	@Override
+	public InputStream openInputStream() throws IOException {
+		return url.openStream();
+	}
+
+}

--- a/library/src/main/java/de/agilecoders/wicket/webjars/util/osgi/BundleUrlType.java
+++ b/library/src/main/java/de/agilecoders/wicket/webjars/util/osgi/BundleUrlType.java
@@ -1,0 +1,42 @@
+package de.agilecoders.wicket.webjars.util.osgi;
+
+import java.net.URL;
+
+import org.osgi.framework.Bundle;
+import org.osgi.framework.FrameworkUtil;
+import org.reflections.vfs.Vfs.Dir;
+import org.reflections.vfs.Vfs.UrlType;
+import org.webjars.AssetLocator;
+
+/**
+ * Manages a bundle {@link URL} type
+ * 
+ * @author ben
+ * 
+ */
+public class BundleUrlType implements UrlType {
+
+	//BD - Note that this changes to bundle in R4.3
+	private static final String BUNDLE_PROTOCOL = "bundleresource";
+
+	@Override
+	public boolean matches(URL url) throws Exception {
+		return BUNDLE_PROTOCOL.equals(url.getProtocol());
+	}
+
+	@Override
+	public Dir createDir(URL url) throws Exception {
+
+		// BD - Use FrameworkUtil to fetch the bundle that this class exists in
+		Bundle bundle = FrameworkUtil.getBundle(AssetLocator.class);
+		Dir dir = null;
+
+		// Assuming it's not null, create a BundleDir
+		if (bundle != null) {
+			dir = new BundleDir(bundle, url);
+		}
+
+		return dir;
+	}
+
+}

--- a/library/src/main/java/de/agilecoders/wicket/webjars/util/osgi/BundleUrlType.java
+++ b/library/src/main/java/de/agilecoders/wicket/webjars/util/osgi/BundleUrlType.java
@@ -16,12 +16,22 @@ import org.webjars.AssetLocator;
  */
 public class BundleUrlType implements UrlType {
 
-	//BD - Note that this changes to bundle in R4.3
-	private static final String BUNDLE_PROTOCOL = "bundleresource";
+	// BD - Note that this changes to bundle in R4.3
+	private static final String[] BUNDLE_PROTOCOLS = { "bundleresource", "bundle" };
 
 	@Override
 	public boolean matches(URL url) throws Exception {
-		return BUNDLE_PROTOCOL.equals(url.getProtocol());
+		boolean result = false;
+
+		for (String protocol : BUNDLE_PROTOCOLS) {
+			result = protocol.equals(url.getProtocol());
+			
+			if(result){
+				break;
+			}
+		}
+		
+		return result;
 	}
 
 	@Override

--- a/library/src/test/java/de/agilecoders/wicket/webjars/util/osgi/BundleDirTest.java
+++ b/library/src/test/java/de/agilecoders/wicket/webjars/util/osgi/BundleDirTest.java
@@ -1,0 +1,83 @@
+package de.agilecoders.wicket.webjars.util.osgi;
+
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Enumeration;
+import java.util.List;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.osgi.framework.Bundle;
+import org.reflections.vfs.Vfs.File;
+
+public class BundleDirTest extends BundleTestBase {
+
+	private BundleDir bundleDir;
+	private Bundle mockBundle;
+
+	@Before
+	public void before() {
+		mockBundle = mock(Bundle.class);
+		bundleDir = new BundleDir(mockBundle, createURL("someFile"));
+	}
+
+	@Test
+	public void testGettingPath() {
+		assertThat(bundleDir.getPath(), is("someFile"));
+	}
+
+	@Test
+	public void testGetFileFromUrlNullEnumeration() {
+		Iterable<File> files = bundleDir.getFiles();
+
+		assertThat(countFiles(files), is(0));
+	}
+
+	@Test
+	public void testGetFileFromUrlFilesAndDirsFound() {
+
+		List<URL> urls = new ArrayList<URL>();
+		urls.add(createURL("someFile"));
+		urls.add(createURL("someDir/"));
+		urls.add(createURL("someOtherFile"));
+
+		Enumeration<URL> urlEnumeration = Collections.enumeration(urls);
+
+		when(mockBundle.findEntries("", "*", true)).thenReturn(urlEnumeration);
+
+		Iterable<File> files = bundleDir.getFiles();
+
+		assertThat(countFiles(files), is(2));
+	}
+
+	@Test
+	public void testGetFileFromUrlOnlyDirsFound() {
+
+		List<URL> urls = new ArrayList<URL>();
+		urls.add(createURL("someDir/"));
+		urls.add(createURL("someOtherDir/"));
+
+		Enumeration<URL> urlEnumeration = Collections.enumeration(urls);
+
+		when(mockBundle.findEntries("", "*", true)).thenReturn(urlEnumeration);
+
+		Iterable<File> files = bundleDir.getFiles();
+
+		assertThat(countFiles(files), is(0));
+	}
+
+	private int countFiles(Iterable<File> files) {
+		int count = 0;
+		for (File file : files) {
+			count++;
+		}
+
+		return count;
+	}
+}

--- a/library/src/test/java/de/agilecoders/wicket/webjars/util/osgi/BundleFileTest.java
+++ b/library/src/test/java/de/agilecoders/wicket/webjars/util/osgi/BundleFileTest.java
@@ -1,0 +1,34 @@
+package de.agilecoders.wicket.webjars.util.osgi;
+
+import static org.hamcrest.core.IsEqual.equalTo;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.junit.Before;
+import org.junit.Test;
+
+public class BundleFileTest extends BundleTestBase {
+
+	private BundleFile bundleFile;
+	private BundleDir mockBundleDir;
+
+	@Before
+	public void before() {
+
+		mockBundleDir = mock(BundleDir.class);
+		bundleFile = new BundleFile(mockBundleDir, createURL("/dir/dir2/file"));
+	}
+
+	@Test
+	public void testGettingRelativePath() {
+		when(mockBundleDir.getPath()).thenReturn("/");
+		assertThat(bundleFile.getRelativePath(), equalTo("dir/dir2/file"));
+	}
+	
+	@Test
+	public void testGettingFileName() {
+		when(mockBundleDir.getPath()).thenReturn("/");
+		assertThat(bundleFile.getName(), equalTo("file"));
+	}
+}

--- a/library/src/test/java/de/agilecoders/wicket/webjars/util/osgi/BundleTestBase.java
+++ b/library/src/test/java/de/agilecoders/wicket/webjars/util/osgi/BundleTestBase.java
@@ -1,0 +1,35 @@
+package de.agilecoders.wicket.webjars.util.osgi;
+
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.mock;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.net.URLStreamHandler;
+
+public class BundleTestBase {
+
+	private URLStreamHandler mockStreamHandler;
+
+	public BundleTestBase() {
+		mockStreamHandler = mock(URLStreamHandler.class);
+	}
+
+	protected URL createURL(String protocol, String file) {
+		URL url = null;
+
+		try {
+			url = new URL(protocol, "host", 0, file, mockStreamHandler);
+		} catch (MalformedURLException e) {
+			e.printStackTrace();
+			fail(e.getMessage());
+		}
+
+		return url;
+	}
+
+	protected URL createURL(String file) {
+		return createURL("protocol", file);
+	}
+
+}

--- a/library/src/test/java/de/agilecoders/wicket/webjars/util/osgi/BundleUrlTypeTest.java
+++ b/library/src/test/java/de/agilecoders/wicket/webjars/util/osgi/BundleUrlTypeTest.java
@@ -1,0 +1,45 @@
+package de.agilecoders.wicket.webjars.util.osgi;
+
+import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.IsNull.nullValue;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+
+import java.net.URL;
+
+import org.junit.Before;
+import org.junit.Test;
+
+public class BundleUrlTypeTest extends BundleTestBase {
+
+	private BundleUrlType urlType;
+
+	@Before
+	public void before() {
+		urlType = new BundleUrlType();
+	}
+
+	@Test
+	public void testAcceptableUrlProtocols() {
+		try {
+
+			URL bundleUrl = createURL("bundle", "file");
+			URL bundleResourceUrl = createURL("bundleresource", "file");
+			URL invalidUrl = createURL("INVALID", "file");
+
+			assertThat(urlType.matches(bundleUrl), is(true));
+			assertThat(urlType.matches(bundleResourceUrl), is(true));
+			assertThat(urlType.matches(invalidUrl), is(false));
+
+		} catch (Exception e) {
+			e.printStackTrace();
+			fail(e.getMessage());
+		}
+	}
+
+	@Test
+	public void testNoOSGiRuntimeGetDir() throws Exception {
+		URL bundleUrl = createURL("bundle", "file");
+		assertThat(urlType.createDir(bundleUrl), nullValue());
+	}
+}

--- a/pom.xml
+++ b/pom.xml
@@ -1,199 +1,226 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
-    <modelVersion>4.0.0</modelVersion>
+	<modelVersion>4.0.0</modelVersion>
 
-    <parent>
-        <groupId>org.sonatype.oss</groupId>
-        <artifactId>oss-parent</artifactId>
-        <version>7</version>
-    </parent>
+	<parent>
+		<groupId>org.sonatype.oss</groupId>
+		<artifactId>oss-parent</artifactId>
+		<version>7</version>
+	</parent>
 
-    <groupId>de.agilecoders.wicket.webjars</groupId>
-    <artifactId>wicket-webjars-parent</artifactId>
-    <packaging>pom</packaging>
-    <version>0.2.1-SNAPSHOT</version>
-    <name>wicket-webjars-parent</name>
-    <description />
-    <url>https://github.com/l0rdn1kk0n/wicket-webjars</url>
+	<groupId>de.agilecoders.wicket.webjars</groupId>
+	<artifactId>wicket-webjars-parent</artifactId>
+	<packaging>pom</packaging>
+	<version>0.2.1-SNAPSHOT</version>
+	<name>wicket-webjars-parent</name>
+	<description />
+	<url>https://github.com/l0rdn1kk0n/wicket-webjars</url>
 
-    <scm>
-        <url>git@github.com:l0rdn1kk0n/wicket-webjars.git</url>
-        <connection>scm:git:git@github.com:l0rdn1kk0n/wicket-webjars.git</connection>
-        <developerConnection>scm:git:git@github.com:l0rdn1kk0n/wicket-webjars.git</developerConnection>
-    </scm>
+	<scm>
+		<url>git@github.com:l0rdn1kk0n/wicket-webjars.git</url>
+		<connection>scm:git:git@github.com:l0rdn1kk0n/wicket-webjars.git</connection>
+		<developerConnection>scm:git:git@github.com:l0rdn1kk0n/wicket-webjars.git</developerConnection>
+	</scm>
 
-    <issueManagement>
-        <system>github</system>
-        <url>https://github.com/l0rdn1kk0n/wicket-webjars/issues</url>
-    </issueManagement>
+	<issueManagement>
+		<system>github</system>
+		<url>https://github.com/l0rdn1kk0n/wicket-webjars/issues</url>
+	</issueManagement>
 
-    <organization>
-        <name>agilecoders.de</name>
-        <url>http://agilecoders.de</url>
-    </organization>
+	<organization>
+		<name>agilecoders.de</name>
+		<url>http://agilecoders.de</url>
+	</organization>
 
-    <prerequisites>
-        <maven>${mvn.version}</maven>
-    </prerequisites>
+	<prerequisites>
+		<maven>${mvn.version}</maven>
+	</prerequisites>
 
-    <modules>
-        <module>library</module>
-        <module>samples</module>
-    </modules>
+	<modules>
+		<module>library</module>
+		<module>webjar-container-fragment</module>
+		<module>samples</module>
+		<module>itests</module>
+	</modules>
 
-    <dependencyManagement>
-        <dependencies>
-            <!--  WICKET DEPENDENCIES -->
-            <dependency>
-                <groupId>org.apache.wicket</groupId>
-                <artifactId>wicket-core</artifactId>
-                <version>${wicket.version}</version>
-            </dependency>
+	<dependencyManagement>
+		<dependencies>
+			<!-- WICKET DEPENDENCIES -->
+			<dependency>
+				<groupId>org.apache.wicket</groupId>
+				<artifactId>wicket-core</artifactId>
+				<version>${wicket.version}</version>
+			</dependency>
 
-            <dependency>
-                <groupId>de.agilecoders.wicket.webjars</groupId>
-                <artifactId>wicket-webjars</artifactId>
-                <version>${project.version}</version>
-            </dependency>
+			<dependency>
+				<groupId>de.agilecoders.wicket.webjars</groupId>
+				<artifactId>wicket-webjars</artifactId>
+				<version>${project.version}</version>
+			</dependency>
 
-            <dependency>
-                <groupId>org.webjars</groupId>
-                <artifactId>webjars-locator</artifactId>
-                <version>0.1</version>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
+			<dependency>
+				<groupId>org.webjars</groupId>
+				<artifactId>webjars-locator</artifactId>
+				<version>0.1</version>
+			</dependency>
+		</dependencies>
+	</dependencyManagement>
 
-    <dependencies>
-        <!--  WICKET DEPENDENCIES -->
-        <dependency>
-            <groupId>org.apache.wicket</groupId>
-            <artifactId>wicket-core</artifactId>
-        </dependency>
+	<dependencies>
+		<!-- WICKET DEPENDENCIES -->
+		<dependency>
+			<groupId>org.apache.wicket</groupId>
+			<artifactId>wicket-core</artifactId>
+		</dependency>
 
-        <dependency>
-            <groupId>org.webjars</groupId>
-            <artifactId>webjars-locator</artifactId>
-        </dependency>
+		<dependency>
+			<groupId>org.webjars</groupId>
+			<artifactId>webjars-locator</artifactId>
+		</dependency>
 
-        <!-- LOGGING DEPENDENCIES - LOG4J -->
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-api</artifactId>
-            <version>1.6.4</version>
-        </dependency>
-    </dependencies>
+		<!-- LOGGING DEPENDENCIES - LOG4J -->
+		<dependency>
+			<groupId>org.slf4j</groupId>
+			<artifactId>slf4j-api</artifactId>
+			<version>1.6.4</version>
+		</dependency>
 
-    <build>
-        <resources>
-            <resource>
-                <filtering>false</filtering>
-                <directory>src/main/resources</directory>
-            </resource>
-            <resource>
-                <filtering>false</filtering>
-                <directory>src/main/java</directory>
-                <includes>
-                    <include>**</include>
-                </includes>
-                <excludes>
-                    <exclude>**/*.java</exclude>
-                </excludes>
-            </resource>
-        </resources>
-        <testResources>
-            <testResource>
-                <filtering>false</filtering>
-                <directory>src/test/java</directory>
-                <includes>
-                    <include>**</include>
-                </includes>
-                <excludes>
-                    <exclude>**/*.java</exclude>
-                </excludes>
-            </testResource>
-        </testResources>
+		<!-- MOCKITO DEPENDENCIES -->
+		<dependency>
+			<groupId>org.mockito</groupId>
+			<artifactId>mockito-all</artifactId>
+			<version>${mockito.version}</version>
+			<scope>test</scope>
+		</dependency>
 
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <version>2.5.1</version>
-                <configuration>
-                    <source>${mvn.build.java.version}</source>
-                    <target>${mvn.build.java.version}</target>
-                    <compilerVersion>${mvn.build.java.version}</compilerVersion>
-                    <encoding>${project.build.sourceEncoding}</encoding>
-                    <showDeprecation>true</showDeprecation>
-                    <showWarnings>true</showWarnings>
-                    <optimize>true</optimize>
-                </configuration>
-            </plugin>
-            <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>versions-maven-plugin</artifactId>
-                <version>${versions-maven-plugin.version}</version>
-                <inherited>true</inherited>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-source-plugin</artifactId>
-                <version>2.2</version>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>jar</goal>
-                            <goal>test-jar</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-jar-plugin</artifactId>
-                <version>2.4</version>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>test-jar</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-        </plugins>
-    </build>
+		<!-- JUNIT DEPENDENCIES -->
+		<dependency>
+			<groupId>junit</groupId>
+			<artifactId>junit</artifactId>
+			<version>${junit.version}</version>
+			<scope>test</scope>
+		</dependency>
+	</dependencies>
 
-    <licenses>
-        <license>
-            <name>The Apache Software License, Version 2.0</name>
-            <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
-            <distribution>repo</distribution>
-        </license>
-    </licenses>
+	<build>
+		<resources>
+			<resource>
+				<filtering>false</filtering>
+				<directory>src/main/resources</directory>
+			</resource>
+			<resource>
+				<filtering>false</filtering>
+				<directory>src/main/java</directory>
+				<includes>
+					<include>**</include>
+				</includes>
+				<excludes>
+					<exclude>**/*.java</exclude>
+				</excludes>
+			</resource>
+		</resources>
+		<testResources>
+			<testResource>
+				<filtering>false</filtering>
+				<directory>src/test/java</directory>
+				<includes>
+					<include>**</include>
+				</includes>
+				<excludes>
+					<exclude>**/*.java</exclude>
+				</excludes>
+			</testResource>
+		</testResources>
 
-    <developers>
-        <developer>
-            <id>miha</id>
-            <name>Michael Haitz</name>
-            <email>michael.haitz@agilecoders.de</email>
-            <organization>agilecoders.de</organization>
-            <roles>
-                <role>Owner</role>
-                <role>Comitter</role>
-            </roles>
-        </developer>
-    </developers>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-compiler-plugin</artifactId>
+				<version>2.5.1</version>
+				<configuration>
+					<source>${mvn.build.java.version}</source>
+					<target>${mvn.build.java.version}</target>
+					<compilerVersion>${mvn.build.java.version}</compilerVersion>
+					<encoding>${project.build.sourceEncoding}</encoding>
+					<showDeprecation>true</showDeprecation>
+					<showWarnings>true</showWarnings>
+					<optimize>true</optimize>
+				</configuration>
+			</plugin>
+			<plugin>
+				<groupId>org.codehaus.mojo</groupId>
+				<artifactId>versions-maven-plugin</artifactId>
+				<version>${versions-maven-plugin.version}</version>
+				<inherited>true</inherited>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-source-plugin</artifactId>
+				<version>2.2</version>
+				<executions>
+					<execution>
+						<goals>
+							<goal>jar</goal>
+							<goal>test-jar</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-jar-plugin</artifactId>
+				<version>2.4</version>
+				<executions>
+					<execution>
+						<goals>
+							<goal>test-jar</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+	</build>
 
-    <properties>
-        <github.global.server>github</github.global.server>
+	<licenses>
+		<license>
+			<name>The Apache Software License, Version 2.0</name>
+			<url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+			<distribution>repo</distribution>
+		</license>
+	</licenses>
 
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <project.reporting.outputEncoding>${project.build.sourceEncoding}</project.reporting.outputEncoding>
-        <mvn.build.java.version>1.6</mvn.build.java.version>
-        <mvn.version>3.0.0</mvn.version>
+	<developers>
+		<developer>
+			<id>miha</id>
+			<name>Michael Haitz</name>
+			<email>michael.haitz@agilecoders.de</email>
+			<organization>agilecoders.de</organization>
+			<roles>
+				<role>Owner</role>
+				<role>Comitter</role>
+			</roles>
+		</developer>
+	</developers>
 
-        <versions-maven-plugin.version>1.3.1</versions-maven-plugin.version>
-        <wicket.version>6.4.0</wicket.version>
-    </properties>
+	<properties>
+		<github.global.server>github</github.global.server>
+
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+		<project.reporting.outputEncoding>${project.build.sourceEncoding}</project.reporting.outputEncoding>
+		<mvn.build.java.version>1.6</mvn.build.java.version>
+		<mvn.version>3.0.0</mvn.version>
+
+		<versions-maven-plugin.version>1.3.1</versions-maven-plugin.version>
+		<wicket.version>6.4.0</wicket.version>
+		<mockito.version>1.9.5</mockito.version>
+		<junit.version>4.11</junit.version>
+		<exam.version>2.6.0</exam.version>
+		<osgi.core.version>4.2.0</osgi.core.version>
+		<karaf.tooling.version>3.0.0.RC1</karaf.tooling.version>
+		<karaf.version>2.3.1</karaf.version>
+		<plugin.depends.version>1.2</plugin.depends.version>
+		<plugin.resources.version>2.6</plugin.resources.version>
+		<plugin.build-helper.version>1.7</plugin.build-helper.version>
+	</properties>
 
 </project>

--- a/webjar-container-fragment/pom.xml
+++ b/webjar-container-fragment/pom.xml
@@ -4,13 +4,13 @@
 	<name>webjar-container-fragment</name>
 	<artifactId>webjar-container-fragment</artifactId>
 	<groupId>de.agilecoders.wicket.webjars</groupId>
-	<version>0.2.0</version>
+	<version>0.2.1-SNAPSHOT</version>
 	<packaging>bundle</packaging>
 
 	<parent>
 		<groupId>de.agilecoders.wicket.webjars</groupId>
 		<artifactId>wicket-webjars-parent</artifactId>
-		<version>0.2.0</version>
+		<version>0.2.1-SNAPSHOT</version>
 	</parent>
 
 	<properties>
@@ -80,4 +80,5 @@
 		</plugins>
 	</build>
 
+	<description>An example of how to provide webjar resources in an OSGi environment.</description>
 </project>

--- a/webjar-container-fragment/pom.xml
+++ b/webjar-container-fragment/pom.xml
@@ -1,0 +1,83 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+	<modelVersion>4.0.0</modelVersion>
+	<name>webjar-container-fragment</name>
+	<artifactId>webjar-container-fragment</artifactId>
+	<groupId>de.agilecoders.wicket.webjars</groupId>
+	<version>0.2.0</version>
+	<packaging>bundle</packaging>
+
+	<parent>
+		<groupId>de.agilecoders.wicket.webjars</groupId>
+		<artifactId>wicket-webjars-parent</artifactId>
+		<version>0.2.0</version>
+	</parent>
+
+	<properties>
+		<jquerypp.version>1.0b2</jquerypp.version>
+		<jquery.version>1.9.0</jquery.version>
+		<modernizr.version>2.6.2-1</modernizr.version>
+	</properties>
+
+	<dependencies>
+		<dependency>
+			<groupId>org.webjars</groupId>
+			<artifactId>bootstrap</artifactId>
+			<version>2.3.1</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.webjars</groupId>
+			<artifactId>jquerypp</artifactId>
+			<version>${jquerypp.version}</version>
+			<exclusions>
+				<exclusion>
+					<groupId>org.webjars</groupId>
+					<artifactId>jquery</artifactId>
+				</exclusion>
+			</exclusions>
+		</dependency>
+
+		<dependency>
+			<groupId>org.webjars</groupId>
+			<artifactId>jquery</artifactId>
+			<version>${jquery.version}</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.webjars</groupId>
+			<artifactId>modernizr</artifactId>
+			<version>${modernizr.version}</version>
+		</dependency>
+
+	</dependencies>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.felix</groupId>
+				<artifactId>maven-bundle-plugin</artifactId>
+				<extensions>true</extensions>
+				<configuration>
+					<instructions>
+						<Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
+						<Bundle-Version>${project.version}</Bundle-Version>
+
+						<!-- Attach this fragment to the webjar bundle, allowing the resource lookup to work -->
+						<Fragment-Host>wrap_mvn_org.webjars_webjars-locator_0.1</Fragment-Host>
+						<Bundle-Classpath>.</Bundle-Classpath>
+
+						<!-- This includes the webjars within this bundle and unpacks them so that we can access their content -->
+						<Embed-Dependency>
+							bootstrap;scope|runtime;inline=true,
+							jquerypp;scope|runtime;inline=true,
+							jquery;scope|runtime;inline=true,
+							modernizr;scope|runtime;inline=true
+						</Embed-Dependency>
+					</instructions>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
+
+</project>

--- a/webjar-container-fragment/pom.xml
+++ b/webjar-container-fragment/pom.xml
@@ -15,15 +15,16 @@
 
 	<properties>
 		<jquerypp.version>1.0b2</jquerypp.version>
-		<jquery.version>1.9.0</jquery.version>
+		<jquery.version>2.0.2</jquery.version>
 		<modernizr.version>2.6.2-1</modernizr.version>
+		<bootstrap.version>2.3.2</bootstrap.version>
 	</properties>
 
 	<dependencies>
 		<dependency>
 			<groupId>org.webjars</groupId>
 			<artifactId>bootstrap</artifactId>
-			<version>2.3.1</version>
+			<version>${bootstrap.version}</version>
 		</dependency>
 
 		<dependency>


### PR DESCRIPTION
Hi Michael,

This is the second part of the OSGi changes for wicket-boostrap.

Two items of note with this one:

Bundle URL Handling

The reflections API didn't have any ability to handle bundle URL's.  This prevented any of the files from being found inside the bundle.  I've created three new classes that are able to cope with bundles and then registered the URL type within the RecentVersionCallable class.  Now when a URL is found starting with bundleresource:// we can handle it.

One downside is that I've had to include a new dependency for the OSGi stuff.


Accessing Webjars Content

Whilst the above lets us peer inside a bundle, we need to have the actual resources appear as through they exist within it.  Hence the need for the fragment.

The pom simply downloads the webjars and then unpacks them into a fragment bundle.  The fragment is then attached to some other bundle, which makes it appear as through it contains the attached files.  In this case we must attach the fragment to the webjars-locator bundle, as the AssetLocator is used to provide the class loader, which in turn is used to find the resources (OSGi doesn't have a monolithic class path like traditional Java apps, it's per bundle.)

The container is just an example, but it's useful as a guide.

Let me know what you think and feel free to get in touch if anything is not clear.

Cheers,

Ben