### PR TITLE
Wicket-Bootstrap #280 - Return null if a resource cannot be found

### DIFF
--- a/library/pom.xml
+++ b/library/pom.xml
@@ -13,6 +13,14 @@
     <packaging>jar</packaging>
     <name>library</name>
 
+    <dependencies>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.11</version>
+        </dependency>
+    </dependencies>
+
     <build>
         <plugins>
             <plugin>

--- a/library/src/main/java/de/agilecoders/wicket/webjars/util/file/WebjarsResourceFinder.java
+++ b/library/src/main/java/de/agilecoders/wicket/webjars/util/file/WebjarsResourceFinder.java
@@ -2,7 +2,6 @@ package de.agilecoders.wicket.webjars.util.file;
 
 import de.agilecoders.wicket.webjars.request.resource.IWebjarsResourceReference;
 import de.agilecoders.wicket.webjars.util.ClasspathUrlStreamHandler;
-import org.apache.wicket.WicketRuntimeException;
 import org.apache.wicket.core.util.resource.UrlResourceStream;
 import org.apache.wicket.util.file.IResourceFinder;
 import org.apache.wicket.util.resource.IResourceStream;

--- a/library/src/test/java/de/agilecoders/wicket/webjars/util/file/WebjarsResourceFinderTest.java
+++ b/library/src/test/java/de/agilecoders/wicket/webjars/util/file/WebjarsResourceFinderTest.java
@@ -1,0 +1,23 @@
+package de.agilecoders.wicket.webjars.util.file;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Tests for WebjarsResourceFinder
+ */
+public class WebjarsResourceFinderTest extends Assert {
+
+    /**
+     * https://github.com/l0rdn1kk0n/wicket-bootstrap/issues/280
+     *
+     * Return {@code null} for missing resources
+     */
+    @Test
+    public void find() {
+        WebjarsResourceFinder finder = new WebjarsResourceFinder();
+
+        assertNull(finder.find(String.class, "non existing"));
+    }
+
+}


### PR DESCRIPTION
A fix for https://github.com/l0rdn1kk0n/wicket-bootstrap/issues/280
The resource finder should not throw an exception when a resource cannot be found.

The problem here was that Wicket first tries to find .min. version of the resource. If the result is null then Wicket asks for the non-min version.
