### PR TITLE
PR #8 - Log a debug when a resource cannot be found

### DIFF
--- a/library/src/main/java/de/agilecoders/wicket/webjars/util/file/WebjarsResourceFinder.java
+++ b/library/src/main/java/de/agilecoders/wicket/webjars/util/file/WebjarsResourceFinder.java
@@ -100,7 +100,7 @@ public class WebjarsResourceFinder implements IResourceFinder {
 
                     stream = newResourceStream(webjarsPath);
                 } catch (Exception e) {
-                    LOG.info("can't locate resource for: {}; {}", pathName, e.getMessage(), e);
+                    LOG.debug("can't locate resource for: {}; {}", pathName, e.getMessage(), e);
                 }
 
                 if (stream == null) {


### PR DESCRIPTION
As reported at http://markmail.org/message/z5a6ltwfmxjmmhsx the INFO message when a resource is not found should really be debug because Wicket tries all combinations of locale/variation/style.
