### PR TITLE
Changed the default webjar cdn value.

### DIFF
--- a/library/src/main/java/de/agilecoders/wicket/webjars/settings/WebjarsSettings.java
+++ b/library/src/main/java/de/agilecoders/wicket/webjars/settings/WebjarsSettings.java
@@ -23,7 +23,7 @@ public class WebjarsSettings implements IWebjarsSettings {
     /**
      * The default base url of the WebJars CDN.
      */
-    private static final String DEFAULT_WEBJAR_CDN = "//cdn.jsdelivr.net:80";
+    private static final String DEFAULT_WEBJAR_CDN = "//cdn.jsdelivr.net:80/webjars/org.webjars";
 
     private Duration readFromCacheTimeout;
     private ResourceStreamProvider resourceStreamProvider;


### PR DESCRIPTION
Now that webjars is serving NPM and Bower packages, the URL for the "classic" webjars has changed.