### PR TITLE
issue-51: circumvent deserialization issues

### DIFF
--- a/library/src/main/java/de/agilecoders/wicket/webjars/request/resource/WebjarsCssResourceReference.java
+++ b/library/src/main/java/de/agilecoders/wicket/webjars/request/resource/WebjarsCssResourceReference.java
@@ -1,10 +1,10 @@
 package de.agilecoders.wicket.webjars.request.resource;
 
-import org.apache.wicket.request.resource.CssResourceReference;
+import static de.agilecoders.wicket.webjars.util.Helper.prependWebjarsPathIfMissing;
 
 import java.util.Locale;
 
-import static de.agilecoders.wicket.webjars.util.WebjarsVersion.useRecent;
+import org.apache.wicket.request.resource.CssResourceReference;
 
 /**
  * Static resource reference for webjars css resources. The resources are filtered (stripped comments and
@@ -25,7 +25,7 @@ public class WebjarsCssResourceReference extends CssResourceReference implements
      * @param name The webjars path to load
      */
     public WebjarsCssResourceReference(final String name) {
-        super(WebjarsCssResourceReference.class, useRecent(name));
+        super(WebjarsCssResourceReference.class, prependWebjarsPathIfMissing(name));
 
         this.originalName = name;
     }

--- a/library/src/main/java/de/agilecoders/wicket/webjars/request/resource/WebjarsJavaScriptResourceReference.java
+++ b/library/src/main/java/de/agilecoders/wicket/webjars/request/resource/WebjarsJavaScriptResourceReference.java
@@ -1,10 +1,12 @@
 package de.agilecoders.wicket.webjars.request.resource;
 
-import org.apache.wicket.request.resource.JavaScriptResourceReference;
+import static de.agilecoders.wicket.webjars.util.Helper.prependWebjarsPathIfMissing;
 
 import java.util.Locale;
 
-import static de.agilecoders.wicket.webjars.util.WebjarsVersion.useRecent;
+import org.apache.wicket.request.resource.JavaScriptResourceReference;
+
+import de.agilecoders.wicket.webjars.util.Helper;
 
 /**
  * Static resource reference for javascript webjars resources. The resources are filtered (stripped comments
@@ -25,7 +27,7 @@ public class WebjarsJavaScriptResourceReference extends JavaScriptResourceRefere
      * @param name The webjars path to load
      */
     public WebjarsJavaScriptResourceReference(final String name) {
-        super(WebjarsJavaScriptResourceReference.class, useRecent(name));
+        super(WebjarsJavaScriptResourceReference.class, prependWebjarsPathIfMissing(name));
 
         this.originalName = name;
     }

--- a/library/src/main/java/de/agilecoders/wicket/webjars/util/file/WebjarsResourceFinder.java
+++ b/library/src/main/java/de/agilecoders/wicket/webjars/util/file/WebjarsResourceFinder.java
@@ -6,6 +6,8 @@ import de.agilecoders.wicket.webjars.util.Helper;
 import de.agilecoders.wicket.webjars.util.IFullPathProvider;
 import de.agilecoders.wicket.webjars.util.IResourceStreamProvider;
 import de.agilecoders.wicket.webjars.util.WebJarAssetLocator;
+import de.agilecoders.wicket.webjars.util.WebjarsVersion;
+
 import org.apache.wicket.util.file.IResourceFinder;
 import org.apache.wicket.util.resource.IResourceStream;
 import org.slf4j.Logger;
@@ -64,21 +66,22 @@ public class WebjarsResourceFinder implements IResourceFinder {
         IResourceStream stream = null;
 
         if (clazz != null && IWebjarsResourceReference.class.isAssignableFrom(clazz)) {
-            final int pos = pathName != null ? pathName.lastIndexOf(Helper.PATH_PREFIX) : -1;
+            String versionnedName = WebjarsVersion.useRecent(pathName);
+            final int pos = versionnedName != null ? versionnedName.lastIndexOf(Helper.PATH_PREFIX) : -1;
 
             if (pos > -1) {
                 try {
-                    final String webjarsPath = locator.getFullPath(pathName.substring(pos));
+                    final String webjarsPath = locator.getFullPath(versionnedName.substring(pos));
 
                     LOG.debug("webjars path: {}", webjarsPath);
 
                     stream = newResourceStream(webjarsPath);
                 } catch (Exception e) {
-                    LOG.debug("can't locate resource for: {}; {}", pathName, e.getMessage());
+                    LOG.debug("can't locate resource for: {} (actual name {}); {}", pathName, versionnedName, e.getMessage());
                 }
 
                 if (stream == null) {
-                    LOG.debug("there is no webjars resource for: {}", pathName);
+                    LOG.debug("there is no webjars resource for: {} (actual name {})", pathName, versionnedName);
                 }
             }
         }


### PR DESCRIPTION
Cf #51

Static fields are initialized at class loading time. When
WicketWebjars*ResourceReference are added on pages or components
as static attributes, and these pages or components are
deserialized (like at container startup time), then
WicketWebjars*ResourceReference are reconstructed.

Constructor calls WebjarsVersion.useRecent(...) method.

As wicket context is not available at this time, this method
fails and page deserialization fails.

This commit moves /recent/ placeholder resolution at resource
delivery time. It implies to perform computations on each
resource delivery in place of on each component initialization,
but it allows to both uses static attributes to store
ResourceReference and allows correct component deserialization
at container startup time.