### PR TITLE
fix /webjars/webjars/ paths, cf #57

### DIFF
--- a/library/src/main/java/de/agilecoders/wicket/webjars/util/WebjarsVersion.java
+++ b/library/src/main/java/de/agilecoders/wicket/webjars/util/WebjarsVersion.java
@@ -1,5 +1,6 @@
 package de.agilecoders.wicket.webjars.util;
 
+
 import de.agilecoders.wicket.webjars.WicketWebjars;
 import de.agilecoders.wicket.webjars.settings.IWebjarsSettings;
 import org.apache.wicket.util.lang.Args;
@@ -14,7 +15,6 @@ import java.util.concurrent.FutureTask;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
-import static de.agilecoders.wicket.webjars.util.Helper.prependWebjarsPathIfMissing;
 
 /**
  * Collects recent versions of webjars resources.
@@ -41,8 +41,6 @@ public final class WebjarsVersion {
      */
     public static String useRecent(String path) {
         Args.notEmpty(path, "path");
-
-        path = prependWebjarsPathIfMissing(path);
 
         if (path.matches(Holder.recentVersionPattern)) {
             return path.replaceFirst(Holder.replacePattern, "/" + recentVersion(path) + "/");

--- a/library/src/main/java/de/agilecoders/wicket/webjars/util/file/WebjarsResourceFinder.java
+++ b/library/src/main/java/de/agilecoders/wicket/webjars/util/file/WebjarsResourceFinder.java
@@ -10,6 +10,7 @@ import de.agilecoders.wicket.webjars.util.WebjarsVersion;
 
 import org.apache.wicket.util.file.IResourceFinder;
 import org.apache.wicket.util.resource.IResourceStream;
+import org.omg.CORBA.VersionSpecHelper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -66,7 +67,11 @@ public class WebjarsResourceFinder implements IResourceFinder {
         IResourceStream stream = null;
 
         if (clazz != null && IWebjarsResourceReference.class.isAssignableFrom(clazz)) {
-            String versionnedName = WebjarsVersion.useRecent(pathName);
+            // pathname as extracted by wicket is a classpath resource path with no leading '/'
+            // historically, webjars file locator works with /webjars/ prefixed path
+            // prepend '/' and resolve version if needed
+            String versionnedName = "/" + pathName;
+            versionnedName = WebjarsVersion.useRecent(versionnedName); 
             final int pos = versionnedName != null ? versionnedName.lastIndexOf(Helper.PATH_PREFIX) : -1;
 
             if (pos > -1) {


### PR DESCRIPTION
See #57 for full history.

Previous #57 57 introduce /webjars/webjars/ path as
prependWebjarsPathIfMissing is now called by WebjarsResourceFinder with
a normalized, leading '/' slash removed, path.

So /webjars/ is added to webjars/... path, and rendered url is ugly.

As WebjarsResourceFinder#find do not really care about /webjars/webjars/
to perform resource resolution, resource delivery was not affected.

This commit remove prependWebjarsPathIfMissing from useRecent, and
normalize provided path (webjars/... -> /webjars/...) so that useRecent
can apply correctly its url pattern matching.