### PR TITLE
Mark optional dependency as `static`

### DIFF
--- a/library/src/main/java/module-info.java
+++ b/library/src/main/java/module-info.java
@@ -11,7 +11,7 @@ module de.agilecoders.wicket.webjars {
 	requires org.apache.wicket.request;
 	requires org.apache.wicket.util;
 
-	requires emory.util.classloader;
+	requires static emory.util.classloader;
 
 	requires org.slf4j;
 }


### PR DESCRIPTION
The dependency `emory.util.classloader` is `optional` in the POM. It is not required in most cases.

This PR makes the dependency optional in the `module-info` as well. Without this change, the dependency needs to be declared in the users POM.