### PR TITLE
issue 167: incorrect asset matching from AssetsMap

### DIFF
--- a/library/src/main/java/de/agilecoders/wicket/webjars/collectors/AssetsMap.java
+++ b/library/src/main/java/de/agilecoders/wicket/webjars/collectors/AssetsMap.java
@@ -102,19 +102,22 @@ public class AssetsMap implements IAssetProvider, IRecentVersionProvider {
     @Override
     public Set<String> listAssets(final String folderPath) {
         final Collection<String> allAssets = getFullPathIndex().values();
+        // ensure that webjarModulePath contains trailing a file separator (bootstrap -> boostrap/)
+        final String webjarModulePath = folderPath.endsWith("/") ? folderPath : folderPath + "/";
 
         final Set<String> assets = new HashSet<>();
 
         final String prefix;
         final String webjarsPath = settings.webjarsPath();
         if (webjarsPath.endsWith("/")) {
-        	prefix = webjarsPath + Helper.removeLeadingSlash(folderPath);
+        	prefix = webjarsPath + Helper.removeLeadingSlash(webjarModulePath);
         } else {
-        	prefix = webjarsPath + Helper.prependLeadingSlash(folderPath);
+        	prefix = webjarsPath + Helper.prependLeadingSlash(webjarModulePath);
         }
         
         for (final String asset : allAssets) {
             if (asset.startsWith(prefix)) {
+            	// all assets in webjarModulePath subpath are candidates
                 assets.add(asset);
             }
         }

--- a/library/src/test/java/de/agilecoders/wicket/webjars/collectors/AssetsMapTest.java
+++ b/library/src/test/java/de/agilecoders/wicket/webjars/collectors/AssetsMapTest.java
@@ -5,7 +5,10 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.util.HashSet;
+import java.util.Map;
 import java.util.Set;
+import java.util.SortedMap;
+import java.util.TreeMap;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -34,5 +37,28 @@ public class AssetsMapTest extends Assertions {
         };
         String versionFor = assetsMap.findRecentVersionFor("realname/current/realname.js");
         assertThat(versionFor, is(equalTo("2.0.0")));
+    }
+
+    /**
+     * https://github.com/martin-g/wicket-webjars/issues/167
+     * 
+     * Matching was done on partial path-component, so bootstrap4 resources matched bootstrap resource lookup.
+     */
+    @Test
+    public void partialPathMatching() {
+        AssetsMap assetsMap = new AssetsMap(new WebjarsSettings()) {
+            public SortedMap<String, String> getFullPathIndex() {
+            	// only values are significant for the use case
+            	// same versions must be used to triggers the issue as versions are put in a Set and first version
+            	// is retrieved.
+                return new TreeMap<>(Map.of(
+                		"0", "META-INF/resources/webjars/bootstrap4/4.6.0/matching.js",
+                		"1", "META-INF/resources/webjars/bootstrap/5.3.2/matching.js"
+                ));
+            }
+        };
+        String versionFor = assetsMap.findRecentVersionFor("/bootstrap/current/matching.js");
+        // bootstrap4 must not match
+        assertThat(versionFor, is(equalTo("5.3.2")));
     }
 }


### PR DESCRIPTION
`listAssets` contract is to list matching assets from a module path. As `folderPath` may not contain a final separater slash `/`, condition based upon `asset.startsWith(prefix)` may return incorrect matches (like `bootstrap4/vX.X.X/dist/js/bootstrap-bundle.js` starts with `bootstrap`, but is in `bootstrap4` module and not bootstrap module).

We add a trailing slash (if not present) to `folderPath` argument to ensure that `startsWith` condition does not match for partial path-component.